### PR TITLE
feat/similar-shape probability-scroll-sched-sort

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -19,7 +19,7 @@
 
     .sidebar {
       padding-right: 1em;
-      padding-top: 0.2em;
+      padding-top: 0.7em;
       flex: 0 0 350px;      
       border-right: 1px solid #ccc;
       /* padding: 1em; */
@@ -42,7 +42,16 @@
       display: block;
       width: 100%;
       max-width: 320px;     
-      margin-bottom: 0.75em;
+      margin-bottom: 0.3em;
+    }
+
+    #clearBtnAndStatus {
+      margin-top: 15px;
+      display: flex;
+      align-items: center;
+      text-align: center;
+      justify-content: center;
+      gap: 1em;
     }
 
     #fetchBtn {
@@ -54,13 +63,16 @@
 
     #clearPaint {
       min-width: 70px;
-      max-width: 70px;
       height: 40px;
     }
 
     #toggleView {
       min-width: 70px;
-      max-width: 70px;
+      height: 40px;
+    }
+
+    #showSimilar {
+      min-width: 70px;
       height: 40px;
     }
 
@@ -122,20 +134,21 @@
     }
 
     #status {
+      margin-top: 1em;
       font-size: 0.9em;
       padding-bottom: 0.7em;
     }
 
     /* TIME TABLE */
     .grid-filter {
-      margin: 1em 0;
+      margin: 0.2em 0;
       font-size: 0.9em;
     }
     .grid-container {
       display: grid;
       /* 1 time‑column + 7 day‑columns = 8 total */
       grid-template-columns: 3em repeat(6, 1fr);
-      grid-auto-rows: 1em; /* this mf is the cell height*/
+      grid-auto-rows: 12px; /* this mf is the cell height*/
       border: 1px solid #ddd;
     }
     .grid-header {
@@ -150,7 +163,7 @@
       border-right: 1px solid #ddd;
       text-align: right;
       padding-right: 0.5em;
-      padding-top: 0.2em;
+      padding-top: 0.1em;
       font-size: 0.6em;
       color: #666;
     }
@@ -160,12 +173,6 @@
     }
     .grid-cell.blocked {
       background: rgba(255, 0, 0, 0.3);
-    }
-
-    #clearBtnAndStatus {
-      display: flex;
-      align-items: center;
-      gap: 1em;
     }
 
     .combo-wrapper {
@@ -258,20 +265,19 @@
       margin-top: 25px;
       pointer-events: auto;
       z-index: 2;
+      /* for scroll bar */
+      max-height: 100%;
+      overflow-x: hidden;
+      overflow-y: auto;
+      padding-right: 0.3em;
     }
     
-    .block:hover::after {
-      min-width: 8em;
-      content: attr(data-sessions);    /* use your own data‑attribute */
-      position: absolute;
-      left: 0; top: 100%;
-      white-space: pre;                /* preserve newlines */
-      background: rgba(0,0,0,0.8);
-      color: #fff;
-      padding: 0.3em;
-      font-size: 0.75em;
+    .block::-webkit-scrollbar {
+      width: 6px;
+    }
+    .block::-webkit-scrollbar-thumb {
+      background: rgba(0,0,0,0.3);
       border-radius: 3px;
-      z-index: 10;
     }
   </style>
 </head>
@@ -293,7 +299,13 @@
       <span>Require <strong>all</strong> fave profs to appear in a combo!</span>
     </label>
 
-    <button id="fetchBtn">Fetch Schedules</button>
+
+    <div id="clearBtnAndStatus">
+      <button id="clearPaint">Clear all times</button>
+      <button id="toggleView">Switch to visual view</button>
+      <button id="showSimilar">Combine Similar Shape</button>
+    </div>
+
 
     <fieldset class="grid-filter">
       <legend>Block out times</legend>
@@ -309,11 +321,9 @@
       </div>
     </fieldset>
 
-    <div id="clearBtnAndStatus">
-      <button id="clearPaint">Clear All</button>
-      <button id="toggleView">Switch to visual</button>
-      <div id="status"></div>
-    </div>
+    <button id="fetchBtn">Fetch Schedules</button>
+
+    <div id="status"></div>
   </div>
 
   <div id="results">

--- a/popup.html
+++ b/popup.html
@@ -256,6 +256,22 @@
       overflow: hidden;
       line-height: 1.1em;
       margin-top: 25px;
+      pointer-events: auto;
+      z-index: 2;
+    }
+    
+    .block:hover::after {
+      min-width: 8em;
+      content: attr(data-sessions);    /* use your own data‑attribute */
+      position: absolute;
+      left: 0; top: 100%;
+      white-space: pre;                /* preserve newlines */
+      background: rgba(0,0,0,0.8);
+      color: #fff;
+      padding: 0.3em;
+      font-size: 0.75em;
+      border-radius: 3px;
+      z-index: 10;
     }
   </style>
 </head>

--- a/popup.html
+++ b/popup.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>CRScheduler</title>
+  <title>CRS Scheduler</title>
   <link rel="icon" type="image/png" href="icons/icon16.png">
   <style>
     body {
@@ -284,7 +284,7 @@
 </head>
 <body>
   <div class="sidebar">
-    <h1>CRScheduler</h1>
+    <h1>CRS Scheduler</h1>
 
     <label for="urls">Enter course URLs here:</label>
     <textarea id="urls" placeholder="Paste URLs, separated by commas" rows="4"></textarea>
@@ -322,7 +322,7 @@
       </div>
     </fieldset>
 
-    <button id="fetchBtn">Fetch Schedules</button>
+    <button id="fetchBtn">Generate Schedules</button>
 
     <div id="status"></div>
   </div>

--- a/popup.html
+++ b/popup.html
@@ -182,10 +182,11 @@
     .combo-header {
       display: flex;
       align-items: center;
-      justify-content: center;
+      justify-content: space-between;
       text-align: center;
-      gap: 500px;
       height: 25px;
+      padding-left: 0.6em;
+      padding-right: 0.6em;
     }
 
     .combo-number {

--- a/popup.html
+++ b/popup.html
@@ -19,7 +19,7 @@
 
     .sidebar {
       padding-right: 1em;
-      padding-top: 1em;
+      padding-top: 0.2em;
       flex: 0 0 350px;      
       border-right: 1px solid #ccc;
       /* padding: 1em; */
@@ -45,11 +45,16 @@
       margin-bottom: 0.75em;
     }
 
-    .sidebar button {
+    #fetchBtn {
       margin-top: 0.7em;
       width: 100%;
       max-width: 330px;
       height: 40px;
+    }
+
+    #clearPaint {
+      width: 20%;
+      height: 20px;
     }
 
     .sidebar label {
@@ -111,6 +116,7 @@
 
     #status {
       font-size: 0.9em;
+      padding-bottom: 0.7em;
     }
 
     /* TIME TABLE */
@@ -148,6 +154,12 @@
     .grid-cell.blocked {
       background: rgba(255, 62, 0, 0.3);
     }
+
+    #clearBtnAndStatus {
+      display: flex;
+      align-items: center;
+      gap: 1em;
+    }
   </style>
 </head>
 <body>
@@ -184,7 +196,10 @@
       </div>
     </fieldset>
 
-    <div id="status"></div>
+    <div id="clearBtnAndStatus">
+      <button id="clearPaint">Clear All</button>
+      <div id="status"></div>
+    </div>
   </div>
 
   <div id="results">

--- a/popup.html
+++ b/popup.html
@@ -11,7 +11,7 @@
       font-family: sans-serif;
       font-size: 1em;       
       display: flex;
-      max-width: 1200px;     
+      width: 1200px;     
       height: 100vh;
       margin: 0 auto;
       overflow: hidden;
@@ -53,8 +53,15 @@
     }
 
     #clearPaint {
-      width: 20%;
-      height: 20px;
+      min-width: 70px;
+      max-width: 70px;
+      height: 40px;
+    }
+
+    #toggleView {
+      min-width: 70px;
+      max-width: 70px;
+      height: 40px;
     }
 
     .sidebar label {
@@ -152,13 +159,103 @@
       cursor: pointer;
     }
     .grid-cell.blocked {
-      background: rgba(255, 62, 0, 0.3);
+      background: rgba(255, 0, 0, 0.3);
     }
 
     #clearBtnAndStatus {
       display: flex;
       align-items: center;
       gap: 1em;
+    }
+
+    .combo-wrapper {
+      border: 1px solid #ddd;
+    }
+
+    .combo-header {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      text-align: center;
+      gap: 500px;
+      height: 25px;
+    }
+
+    .combo-number {
+      font-size: 14.4px;
+    }
+
+    .combo-probability {
+      font-size: 14.4px;
+    }
+
+    /* container for each mini‑timetable */
+    .timetable-combo {
+      display: grid;
+      grid-template-columns: 0.90fr repeat(6, 2fr);
+      /* 1 header row + 25 half‑hour rows */
+      /* grid-template-rows: 1.2em repeat(25, 1.3px); */
+      grid-auto-rows: 15px; /* each row has a height of 15px */
+      gap: 0;
+      font-size: 0.7em;
+      position: relative;
+      height: 390px;
+      /* margin-bottom: 1em; */
+    }
+
+    /* day headers (Mon–Sat) */
+    .day-header {
+      grid-row: 1;
+      background: #f0f0f0;
+      text-align: center;
+      border: 1px solid #ddd;
+      line-height: 1.2em;
+      font-size: 0.8em;
+      font-weight: bold;
+    }
+
+    /* time‑of‑day labels down the left */
+    .time-label {
+      grid-column: 1;
+      text-align: right;
+      padding-right: 0.4em;
+      color: #666;
+      font-size: 0.8em;
+      min-width: 2.5em;
+      white-space: nowrap;
+      height: 15px;
+      margin-bottom: 3em;
+    }
+
+    /* ts put the horizontal grid lines below the layer of the timetable */
+    .timetable-combo > * {
+      position: relative;
+      z-index: 1;
+    }
+
+    .timetable-combo::before {
+      content: "";
+      position: absolute;
+      top: 0; right: 0; bottom: 0; left: 0;
+      background-image:
+        repeating-linear-gradient(to bottom,#ddd,#ddd 1px,transparent 1px,transparent 15px); 
+      pointer-events: none;
+      z-index: 0;
+    }
+
+    /* each class “block” */
+    .block {
+      position: absolute;
+      box-sizing: border-box;
+      /* left: calc( (var(--col-width) + 1px) * (attr(data-day-idx number) + 1) ); */
+      /* width: calc(var(--col-width)); */
+      background: rgb(220, 156, 156);
+      border: 0.2px solid rgba(200, 0, 0, 1);
+      font-size: 0.65em;
+      padding: 0.1em;
+      overflow: hidden;
+      line-height: 1.1em;
+      margin-top: 25px;
     }
   </style>
 </head>
@@ -198,6 +295,7 @@
 
     <div id="clearBtnAndStatus">
       <button id="clearPaint">Clear All</button>
+      <button id="toggleView">Switch to visual</button>
       <div id="status"></div>
     </div>
   </div>

--- a/popup.js
+++ b/popup.js
@@ -1,182 +1,4 @@
-function getBlockedTimes() {
-  const blocked = [];
-  document.querySelectorAll('.grid-cell').forEach(cell => {
-    if (cell.dataset.blocked === 'true') {
-      blocked.push({
-        day: cell.dataset.day,
-        slot: Number(cell.dataset.slot),
-        // optional human‑readable time:
-        time: slotToTime(Number(cell.dataset.slot))
-      });
-    }
-  });
-  return blocked;
-}
-
-// TODO: small improvement is to memoize this
-function slotToTime(slot) {
-  const hour = 7 + Math.floor(slot/2);
-  const minute = slot % 2 === 0 ? '00' : '30';
-  const ampm = hour < 12 ? 'AM' : 'PM';
-  const h12 = ((hour + 11) % 12) + 1;
-  return `${h12}:${minute} ${ampm}`;
-}
-
-// TODO: small improvement is to memoize this
-function timeToSlots(timeStr) {
-  let [rawStart, rawEnd] = timeStr.split('-').map(s => s.trim());
-  // pull off AM/PM from end
-  const mEnd = rawEnd.match(/(AM|PM)$/i);
-  if (!mEnd) throw new Error("Cannot parse end time: " + rawEnd);
-  const ampm = mEnd[1].toUpperCase();
-  let end = rawEnd.replace(/(AM|PM)$/i, '');
-  let start = rawStart;
-
-  // if start has no AM/PM, tack on the one from end
-  if (!/AM|PM$/i.test(start)) start += ampm;
-
-  // ensure both have minutes
-  function normalize(t) {
-    // now t looks like “H” or “H:MM” plus AM/PM
-    const m = t.match(/^(\d{1,2})(?::(\d{2}))?(AM|PM)$/i);
-    if (!m) throw new Error("Bad time: " + t);
-    let h = parseInt(m[1],10), mm = m[2] ? parseInt(m[2],10) : 0, ap = m[3].toUpperCase();
-    // roll 12‑hour to 24‑hour
-    if (h === 12) h = ap === 'AM' ? 0 : 12;
-    else if (ap === 'PM') h += 12;
-    return { h, mm };
-  }
-
-  const s = normalize(start);
-  const e = normalize(end + ampm);
-
-  // compute minutes since 7:00
-  const toSlot = ({h, mm}) => ((h * 60 + mm) - (7 * 60)) / 30; // Don't floor this to output floating points. This is so that we account for 11:45, 12:45...
-
-  return [ toSlot(s), toSlot(e) ];
-}
-
-// Global map for day parsing, maybe there's a better way of doing this
-// TODO: improve this
-const dayMap = {
-  "M": ["Monday"],
-  "T": ["Tuesday"],
-  "W": ["Wednesday"],
-  "Th": ["Thursday"],
-  "F": ["Friday"],
-  "S": ["Saturday"],
-  "Su": ["Sunday"],
-  "MWF": ["Monday", "Wednesday", "Friday"],
-  "TTh": ["Tuesday", "Thursday"],
-  "WF": ["Wednesday", "Friday"],
-  "TF": ["Tuesday", "Friday"],
-  "MW": ["Monday", "Wednesday"],
-  "MTWThF": ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"]
-};
-
-// For caching -> { urlKey: JSON payload }
-const scheduleCache = new Map();
-
-document.addEventListener('DOMContentLoaded', async () => {
-  // This is for the visual or table view button
-  let isVisual = false;
-  let lastArgs = null;
-  document.getElementById('toggleView').addEventListener('click', () => {
-    if (!lastArgs) return; // nothing to show yet
-    isVisual = !isVisual;
-    document.getElementById('toggleView').textContent = isVisual ? 'Switch to table' : 'Switch to visual';
-    // Rerender with the same filters + data
-    renderTable(...lastArgs);
-  });
-
-
-  // For dynamic rendering of table and infinite scrolling
-  const CHUNK_SIZE = 20;
-  let currentStart = 0;
-
-  // For detecting whether there are or no matches found when generating schedule combinations
-  let anyRendered = false;
-
-
-  // Format the table at the sidebar by generating time slots with for loop, hard coding div's is tiring
-  const container = document.querySelector('.grid-container');
-  for (let slot = 0; slot < 25; slot++) {
-    // 1) time label
-    const hour = 7 + Math.floor(slot / 2);
-    const minute = slot % 2 === 0 ? '00' : '30';
-    const ampm = hour < 12 ? 'AM' : 'PM';
-    const displayHour = ((hour + 11) % 12) + 1;
-    const label = document.createElement('div');
-    label.className = 'grid-times';
-    label.textContent = `${displayHour}:${minute} ${ampm}`;
-    container.appendChild(label);
-
-    // 2) one cell per day Mon–Sat (6)
-    for (let day = 0; day < 6; day++) {
-      const cell = document.createElement('div');
-      cell.className = 'grid-cell';
-      cell.dataset.blocked = 'false';
-      cell.addEventListener('click', () => {
-        cell.dataset.blocked = cell.dataset.blocked === 'true' ? 'false' : 'true';
-        cell.classList.toggle('blocked');
-      });
-
-      cell.dataset.day = ['Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'][day];
-      cell.dataset.slot = slot;  
-
-      container.appendChild(cell);
-    }
-  }
-
-  // -----------------------
-  // Time table painting logic
-  let isMouseDown = false;
-  let paintMode = null; // "block" or "unblock"
-
-  // This is called if dragging mouse click
-  function applyPaint(cell) {
-    if (paintMode === 'block') {
-      cell.dataset.blocked = 'true';
-      cell.classList.add('blocked');
-    } else if (paintMode === 'unblock') {
-      cell.dataset.blocked = 'false';
-      cell.classList.remove('blocked');
-    }
-  }
-
-  // Basically two modes of input:
-  // 1) Single‐click toggle
-  container.addEventListener('click', e => {
-    if (!e.target.classList.contains('grid-cell')) return;
-    const cell = e.target;
-    const blocked = cell.dataset.blocked === 'true';
-    cell.dataset.blocked = (!blocked).toString();
-    cell.classList.toggle('blocked', !blocked);
-  });
-
-  // 2) Brush‐painting on drag
-  container.addEventListener('mousedown', e => {
-    if (!e.target.classList.contains('grid-cell')) return;
-    isMouseDown = true;
-    // decide if we're blocking or unblocking
-    paintMode = e.target.dataset.blocked === 'true' ? 'unblock' : 'block';
-    applyPaint(e.target);
-    e.preventDefault(); // prevents text selection
-  });
-
-  container.addEventListener('mouseover', e => {
-    if (!isMouseDown) return;
-    if (!e.target.classList.contains('grid-cell')) return;
-    applyPaint(e.target);
-  });
-
-  window.addEventListener('mouseup', () => {
-    isMouseDown = false;
-    paintMode = null;
-  });
-  // -----------------------
-
-
+document.addEventListener('DOMContentLoaded', () => {
   // Grab manifest
   const manifest = chrome.runtime.getManifest();
   console.log('manifest', manifest);
@@ -393,6 +215,9 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   function getFilteredGroups(groups, rawProfs, strict, forbiddenSlots) {
+    // Make sure to clear this every render of a new table
+    similarShapeCombinations.clear();
+
     // Build a set of forbidden slots in this manner: Mon|5, Tue|4, ...
     const forbiddenSet = new Set(forbiddenSlots.map(({ day, slot }) => `${day}|${slot}`));
 
@@ -450,6 +275,25 @@ document.addEventListener('DOMContentLoaded', async () => {
       } 
 
       // Passed all the filters here! Nice!
+      // We can insert the similar shape algorithm here by appending into a dictionary called similarShapeCombinations, with sorted concatenated time slots as keys, and courses as values.
+            
+      console.log('Filtered occupiedSet', occupiedSet);
+
+      // Sort the occupiedSet for consistent ordering (optional, for debugging or grouping)
+      const sortedOccupied = Array.from(occupiedSet).sort();
+      // You can use sortedOccupied instead of occupiedSet if you want a sorted array
+      // console.log('Sorted occupiedSet', sortedOccupied);
+
+      let timeSlotKey = sortedOccupied.join(',');
+
+      console.log('timeSlotKey', timeSlotKey);
+
+      // Append the current group (course details) to the similarShapeCombinations map
+      if (!similarShapeCombinations.has(timeSlotKey)) { // If first time palang nakikita
+        similarShapeCombinations.set(timeSlotKey, []);
+      }
+      similarShapeCombinations.get(timeSlotKey).push(group);
+
       return true; 
     });
   }
@@ -460,15 +304,15 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     const filtered = getFilteredGroups(groups, rawProfs, strict, forbiddenSlots);
     // console.log('filtered', filtered);
+    console.log('similarShapeCombinations', similarShapeCombinations);
 
     status.textContent = `Generated ${filtered.length} combinations.`; // Show a status of how many schedule combination was generated and filtered
     
     if (filtered.length === 0) {
-      document.getElementById('results').innerHTML = '<p>⚠️ No matching combinations found.</p>';
+      results.innerHTML = '<p>⚠️ No matching combinations found.</p>';
       return;
     }
 
-    const results = document.getElementById('results');
     results.scrollTop = 0; // This fixes the not resetting the scroll to top bug!
     results.innerHTML = ''; // Clear everything
 
@@ -484,6 +328,70 @@ document.addEventListener('DOMContentLoaded', async () => {
       th.textContent = c;
       headerTemplate.appendChild(th);
     });
+
+    if (similarShapeCombinations.size === 0) {
+      results.innerHTML = '<p>⚠️ No matching combinations found.</p>';
+      return;
+    }
+
+    // Add a new button here that listens to activate renderSimilarShapeCombination
+    const similarShapeBtn = document.createElement('button');
+    similarShapeBtn.id = 'showSimilarShape';
+    similarShapeBtn.textContent = 'Show Similar Shape Combinations';
+    results.appendChild(similarShapeBtn);
+
+    similarShapeBtn.addEventListener('click', () => {
+      results.innerHTML = '';
+      renderSimilarShapeCombination(filtered, rawProfs, strict, forbiddenSlots, cols, table, headerTemplate); 
+    });    
+
+    if (similarShapeCombinations.size === 0) {
+      results.innerHTML = '<p>⚠️ No matching combinations found.</p>';
+      return;
+    }
+
+    // Add a new button here that listens to activate renderSimilarShapeCombination
+    const similarShapeBtn = document.createElement('button');
+    similarShapeBtn.id = 'showSimilarShape';
+    similarShapeBtn.textContent = 'Show Similar Shape Combinations';
+    results.appendChild(similarShapeBtn);
+
+    similarShapeBtn.addEventListener('click', () => {
+      results.innerHTML = '';
+      renderSimilarShapeCombination(filtered, rawProfs, strict, forbiddenSlots, cols, table, headerTemplate); 
+    });    
+
+    if (similarShapeCombinations.size === 0) {
+      results.innerHTML = '<p>⚠️ No matching combinations found.</p>';
+      return;
+    }
+
+    // Add a new button here that listens to activate renderSimilarShapeCombination
+    const similarShapeBtn = document.createElement('button');
+    similarShapeBtn.id = 'showSimilarShape';
+    similarShapeBtn.textContent = 'Show Similar Shape Combinations';
+    results.appendChild(similarShapeBtn);
+
+    similarShapeBtn.addEventListener('click', () => {
+      results.innerHTML = '';
+      renderSimilarShapeCombination(filtered, rawProfs, strict, forbiddenSlots, cols, table, headerTemplate); 
+    });    
+
+    if (similarShapeCombinations.size === 0) {
+      results.innerHTML = '<p>⚠️ No matching combinations found.</p>';
+      return;
+    }
+
+    // Add a new button here that listens to activate renderSimilarShapeCombination
+    const similarShapeBtn = document.createElement('button');
+    similarShapeBtn.id = 'showSimilarShape';
+    similarShapeBtn.textContent = 'Show Similar Shape Combinations';
+    results.appendChild(similarShapeBtn);
+
+    similarShapeBtn.addEventListener('click', () => {
+      results.innerHTML = '';
+      renderSimilarShapeCombination(filtered, rawProfs, strict, forbiddenSlots, cols, table, headerTemplate); 
+    });    
 
     // Append the table first
     currentStart = 0;
@@ -757,5 +665,135 @@ document.addEventListener('DOMContentLoaded', async () => {
       observer.disconnect();
       sentinel.remove();
     }
+  }
+
+  function renderSimilarShapeCombination(groups, rawProfs, strict, forbiddenSlots, cols, table, headerTemplate) {
+    const shapeSummaries = Array.from(similarShapeCombinations.entries()).map(
+      ([shapeKey, groupsForShape]) => {
+        const slots = shapeKey.split(',').map(pair => {
+          const [day, slot] = pair.split('|');
+          return { day: day, slot: parseFloat(slot) };
+        });
+
+        return { slots, groupsForShape }
+      }
+    );
+    console.log('shapeSummaries', shapeSummaries);   
+
+    // TODO: render here visually
+    const end = Math.min(shapeSummaries.length, currentStart + CHUNK_SIZE); // For deciding how many to show at once initially
+
+    const slotHeight = 15;
+    const dayWidth = 124.19;
+
+    shapeSummaries.forEach(({ slots, groupsForShape }, shapeIndex) => {
+      // wrapper + header
+      const comboWrapper = document.createElement('div');
+      comboWrapper.classList.add('combo-wrapper');
+
+      const hdr = document.createElement('div');
+      hdr.classList.add('combo-header');
+      hdr.innerHTML = `<div class="combo-number">Shape ${shapeIndex + 1}</div>`;
+      comboWrapper.appendChild(hdr);
+
+      // grid container
+      const timetableCombo = document.createElement('div');
+      timetableCombo.classList.add('timetable-combo');
+
+      // column headers
+      ['Mon','Tue','Wed','Thu','Fri','Sat'].forEach((d,i) => {
+        const dh = document.createElement('div');
+        dh.classList.add('day-header');
+        dh.style.gridColumn = (i+2).toString();
+        dh.textContent = d;
+        timetableCombo.appendChild(dh);
+      });
+
+      // row labels
+      for (let slot=0; slot<25; slot++){
+        const hour = 7+Math.floor(slot/2),
+              min  = slot%2?'30':'00',
+              ampm = hour<12?'AM':'PM',
+              h12  = ((hour+11)%12)+1;
+        const lbl = document.createElement('div');
+        lbl.classList.add('time-label');
+        lbl.style.gridRow = (slot+2).toString();
+        lbl.textContent = `${h12}:${min} ${ampm}`;
+        timetableCombo.appendChild(lbl);
+      }
+
+      // 3) Collect _all_ sessions in this shape
+      const sessions = [];
+      groupsForShape.forEach(group => {
+        group.forEach(item => {
+          const course = Object.keys(item)[0];
+          item[course].forEach(sectionObj => {
+            const section = Object.keys(sectionObj)[0];
+            sectionObj[section].forEach(detail => {
+              const days = dayMap[detail.Day] || [];
+              const [s,e] = timeToSlots(detail.Time);
+              days.forEach(fullDay => {
+                const dayIdx = ['Mon','Tue','Wed','Thu','Fri','Sat']
+                                .indexOf(fullDay.slice(0,3));
+                if (dayIdx >= 0) {
+                  sessions.push({
+                    dayIdx, s, e,
+                    label: `${course} ${section}`
+                  });
+                }
+              });
+            });
+          });
+        });
+      });
+
+      // 4) Cluster identical (dayIdx, s, e)
+      const shapeMap = new Map();
+      sessions.forEach(sess => {
+        const key = `${sess.dayIdx}|${sess.s}|${sess.e}`;
+        if (!shapeMap.has(key)) shapeMap.set(key, []);
+        shapeMap.get(key).push(sess);
+      });
+
+      // 5) Draw one <div class="block"> per cluster
+      shapeMap.forEach(arr => {
+        const { dayIdx, s, e } = arr[0];
+        const block = document.createElement('div');
+        block.classList.add('block');
+        block.style.left   = `${(dayIdx+1)*dayWidth - 67}px`;
+        block.style.width  = `${dayWidth-2}px`;
+        block.style.top    = `${s*slotHeight - 10}px`;
+        block.style.height = `${(e-s)*slotHeight}px`;
+
+        // tooltip list of all labels in this block
+        block.title = arr.map(x => x.label).join('\n');
+        const sessionLabels = arr.map(x => x.label).join("\n");
+        block.setAttribute('data-sessions', sessionLabels);
+
+        // show the first course inside
+        block.innerHTML = `<strong>${arr[0].label}</strong>`;
+        timetableCombo.appendChild(block);
+      });
+
+
+      anyRendered = true;
+      comboWrapper.appendChild(timetableCombo);
+      results.appendChild(comboWrapper);
+    });
+
+    currentStart = end;
+
+    // console.log('sentinel', sentinel);
+
+    // Append the sentinel at the bottom after each chunk is rendered
+    if (currentStart < shapeSummaries.length) {
+      results.appendChild(sentinel);
+    }
+
+    if (currentStart >= shapeSummaries.length) {
+      observer.disconnect();
+      sentinel.remove();
+    }
+
   }
 });

--- a/popup.js
+++ b/popup.js
@@ -1,4 +1,166 @@
+function getBlockedTimes() {
+  const blocked = [];
+  document.querySelectorAll('.grid-cell').forEach(cell => {
+    if (cell.dataset.blocked === 'true') {
+      blocked.push({
+        day: cell.dataset.day,
+        slot: Number(cell.dataset.slot),
+        // optional human‑readable time:
+        time: slotToTime(Number(cell.dataset.slot))
+      });
+    }
+  });
+  return blocked;
+}
+
+function slotToTime(slot) {
+  const hour = 7 + Math.floor(slot/2);
+  const minute = slot % 2 === 0 ? '00' : '30';
+  const ampm = hour < 12 ? 'AM' : 'PM';
+  const h12 = ((hour + 11) % 12) + 1;
+  return `${h12}:${minute} ${ampm}`;
+}
+
+function timeToSlots(timeStr) {
+  let [rawStart, rawEnd] = timeStr.split('-').map(s => s.trim());
+  // pull off AM/PM from end
+  const mEnd = rawEnd.match(/(AM|PM)$/i);
+  if (!mEnd) throw new Error("Cannot parse end time: " + rawEnd);
+  const ampm = mEnd[1].toUpperCase();
+  let end = rawEnd.replace(/(AM|PM)$/i, '');
+  let start = rawStart;
+
+  // if start has no AM/PM, tack on the one from end
+  if (!/AM|PM$/i.test(start)) start += ampm;
+
+  // ensure both have minutes
+  function normalize(t) {
+    // now t looks like “H” or “H:MM” plus AM/PM
+    const m = t.match(/^(\d{1,2})(?::(\d{2}))?(AM|PM)$/i);
+    if (!m) throw new Error("Bad time: " + t);
+    let h = parseInt(m[1],10), mm = m[2] ? parseInt(m[2],10) : 0, ap = m[3].toUpperCase();
+    // roll 12‑hour to 24‑hour
+    if (h === 12) h = ap === 'AM' ? 0 : 12;
+    else if (ap === 'PM') h += 12;
+    return { h, mm };
+  }
+
+  const s = normalize(start);
+  const e = normalize(end + ampm);
+
+  // compute minutes since 7:00
+  const toSlot = ({h, mm}) => Math.floor(((h * 60 + mm) - (7 * 60)) / 30);
+
+  return [ toSlot(s), toSlot(e) ];
+}
+
+// Global map for day parsing, maybe there's a better way of doing this
+// TODO: improve this
+const dayMap = {
+  "M": ["Monday"],
+  "T": ["Tuesday"],
+  "W": ["Wednesday"],
+  "Th": ["Thursday"],
+  "F": ["Friday"],
+  "S": ["Saturday"],
+  "Su": ["Sunday"],
+  "MWF": ["Monday", "Wednesday", "Friday"],
+  "TTh": ["Tuesday", "Thursday"],
+  "WF": ["Wednesday", "Friday"],
+  "TF": ["Tuesday", "Friday"],
+  "MW": ["Monday", "Wednesday"],
+  "MTWThF": ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"]
+};
+
+// For caching -> { urlKey: JSON payload }
+const scheduleCache = new Map();
+
 document.addEventListener('DOMContentLoaded', () => {
+  // For dynamic rendering of table
+  const CHUNK_SIZE = 20;
+
+  // For detecting whether there are or no matches found in renderTable
+  let anyRendered = false;
+
+  // Format the table by generating time slots with for loop, hard coding div's is tiring
+  const container = document.querySelector('.grid-container');
+  for (let slot = 0; slot < 25; slot++) {
+    // 1) time label
+    const hour = 7 + Math.floor(slot / 2);
+    const minute = slot % 2 === 0 ? '00' : '30';
+    const ampm = hour < 12 ? 'AM' : 'PM';
+    const displayHour = ((hour + 11) % 12) + 1;
+    const label = document.createElement('div');
+    label.className = 'grid-times';
+    label.textContent = `${displayHour}:${minute} ${ampm}`;
+    container.appendChild(label);
+
+    // 2) one cell per day Mon–Sat (6)
+    for (let day = 0; day < 6; day++) {
+      const cell = document.createElement('div');
+      cell.className = 'grid-cell';
+      cell.dataset.blocked = 'false';
+      cell.addEventListener('click', () => {
+        cell.dataset.blocked = cell.dataset.blocked === 'true' ? 'false' : 'true';
+        cell.classList.toggle('blocked');
+      });
+
+      cell.dataset.day = ['Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'][day];
+      cell.dataset.slot = slot;  
+
+      container.appendChild(cell);
+    }
+  }
+
+  // -----------------------
+  // Time table painting logic
+  let isMouseDown = false;
+  let paintMode = null; // "block" or "unblock"
+
+  // This is called if dragging mouse click
+  function applyPaint(cell) {
+    if (paintMode === 'block') {
+      cell.dataset.blocked = 'true';
+      cell.classList.add('blocked');
+    } else if (paintMode === 'unblock') {
+      cell.dataset.blocked = 'false';
+      cell.classList.remove('blocked');
+    }
+  }
+
+  // Basically two modes of input:
+  // 1) Single‐click toggle
+  container.addEventListener('click', e => {
+    if (!e.target.classList.contains('grid-cell')) return;
+    const cell = e.target;
+    const blocked = cell.dataset.blocked === 'true';
+    cell.dataset.blocked = (!blocked).toString();
+    cell.classList.toggle('blocked', !blocked);
+  });
+
+  // 2) Brush‐painting on drag
+  container.addEventListener('mousedown', e => {
+    if (!e.target.classList.contains('grid-cell')) return;
+    isMouseDown = true;
+    // decide if we're blocking or unblocking
+    paintMode = e.target.dataset.blocked === 'true' ? 'unblock' : 'block';
+    applyPaint(e.target);
+    e.preventDefault(); // prevents text selection
+  });
+
+  container.addEventListener('mouseover', e => {
+    if (!isMouseDown) return;
+    if (!e.target.classList.contains('grid-cell')) return;
+    applyPaint(e.target);
+  });
+
+  window.addEventListener('mouseup', () => {
+    isMouseDown = false;
+    paintMode = null;
+  });
+  // -----------------------
+
+
   // Grab manifest
   const manifest = chrome.runtime.getManifest();
   console.log('manifest', manifest);
@@ -37,6 +199,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
 
   document.getElementById('fetchBtn').addEventListener('click', async () => {
+    // Fetch from the timetable
+    const forbiddenSlots = getBlockedTimes();
+    console.log('User blocked these:', forbiddenSlots);
+
     // Put this locally instead of globally to catch the input right away.
     // Then we feed this in renderTable.
     const faveProfsInput = document.getElementById('professorName');
@@ -63,138 +229,207 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     const urls = raw.split(',').map(u=>u.trim()).filter(u=>u);
+    const urlKey = urls.slice().sort().join('');
+    console.log('urlKey', urlKey);
 
-    try {
-      status.textContent = 'Fetching priorities…';
-      // 1.0 Get classmessages and scrape priorities HTML page
-      const classMsgResp = await fetch('https://crs.upd.edu.ph/user/view/classmessages', {
-        credentials: 'include'
-      });
-      const classMsgHtml = await classMsgResp.text();
+    // IMPORTANT! To not fetch the same URLs over and over again, which makes it slow, we need to cache the JSON payload from the URLs.
+    if (scheduleCache.has(urlKey)) {
+      const cached = scheduleCache.get(urlKey); // This is now the previously fetched JSON with the same URL
+      console.log("Using cached schedules!");
+      return renderTable(cached, rawProfs, strict, forbiddenSlots);
 
-      // 1.1 Feed the classmessages HTML page to /scrape-priority endpoint
-      const prioResp = await fetch(`${BACKEND}/scrape-priority`, {
-        method: 'POST',
-        headers: {
-          'Accept': 'application/json',
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({ html: classMsgHtml })
-      });
-
-      const prioJson = await prioResp.json();
-      if (prioJson.status !== 'success') {
-        throw new Error(prioJson.message || 'Failed to scrape priorities');
-      }
-      const { preenlistment_priority, registration_priority } = prioJson;
-
-      // 2. Get HTML pages for each course URL and scrape each table by calling the backend
-      let allSchedules = [];
-      let allCourseHTML = [];
-      let isPreenlismentLink = false;
-      let isRegistrationLink = false;
-      let endpointCall = "";
-
-      let preenlistmentCount = 0;
-      let registrationCount = 0;
-
-      for (let url of urls) {
-        // Temporarily comment these
-        // status.textContent = `Processing ${url}…`;
-
-        if (url.includes('/preenlistment')) preenlistmentCount++;
-        if (url.includes('/student_registration')) registrationCount++;
-
-        // // fetch the course page HTML
-        // const courseResp = await fetch(url, { credentials: 'include' });
-        // const courseHtml = await courseResp.text();
-        // allCourseHTML.push(courseHtml);
-      }
-
-      // 3. Ensure all URLs are of the same type
-      if (preenlistmentCount === urls.length) {
-        endpointCall = '/scrape-links-preenlistment';
-      } else if (registrationCount === urls.length) {
-        endpointCall = '/scrape-links-registration';
-      } else {
-        throw new Error('All URLs must be either preenlistment or registration links.');
-      }
-
-      // Temporarily
-      endpointCall = '/test-schedules';
-
-      // 4. Call the backend endpoint call
-      let linkResponse;
+    } else {
+      // We need to do the ordinary fetching. Make sure to set in scheduleCache!
       try {
-        linkResponse = await fetch(
-          `${BACKEND}${endpointCall}`, 
-          {
-            method: 'GET',
-            headers: {
-              'Accept': 'application/json',
-              'Content-Type': 'application/json'
+        // TODO: Only fetch priority once!
+        status.textContent = 'Fetching priorities...';
+        // 1.0 Get classmessages and scrape priorities HTML page
+        const classMsgResp = await fetch('https://crs.upd.edu.ph/user/view/classmessages', {
+          credentials: 'include'
+        });
+        const classMsgHtml = await classMsgResp.text();
+
+        // 1.1 Feed the classmessages HTML page to /scrape-priority endpoint
+        const prioResp = await fetch(`${BACKEND}/scrape-priority`, {
+          method: 'POST',
+          headers: {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({ html: classMsgHtml })
+        });
+
+        const prioJson = await prioResp.json();
+        if (prioJson.status !== 'success') {
+          throw new Error(prioJson.message || 'Failed to scrape priorities');
+        }
+        const { preenlistment_priority, registration_priority } = prioJson;
+
+        // 2. Get HTML pages for each course URL and scrape each table by calling the backend
+        let allSchedules = [];
+        let allCourseHTML = [];
+        let isPreenlismentLink = false;
+        let isRegistrationLink = false;
+        let endpointCall = "";
+
+        let preenlistmentCount = 0;
+        let registrationCount = 0;
+
+        for (let url of urls) {
+          // Temporarily comment these
+          // status.textContent = `Processing ${url}...`;
+
+          if (url.includes('/preenlistment')) preenlistmentCount++;
+          if (url.includes('/student_registration')) registrationCount++;
+
+          // // fetch the course page HTML
+          // const courseResp = await fetch(url, { credentials: 'include' });
+          // const courseHtml = await courseResp.text();
+          // allCourseHTML.push(courseHtml);
+        }
+
+        // 3. Ensure all URLs are of the same type
+        if (preenlistmentCount === urls.length) {
+          endpointCall = '/scrape-links-preenlistment';
+        } else if (registrationCount === urls.length) {
+          endpointCall = '/scrape-links-registration';
+        } else {
+          throw new Error('All URLs must be either preenlistment or registration links.');
+        }
+
+        // Temporarily
+        endpointCall = '/test-schedules2';
+
+        // 4. Call the backend endpoint call
+        let linkResponse;
+        try {
+          status.textContent = 'Processing URLs...'; // Temporarily
+          linkResponse = await fetch(
+            `${BACKEND}${endpointCall}`, 
+            {
+              method: 'GET',
+              headers: {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json'
+              }
             }
+          );
+          if (!linkResponse.ok) {
+            throw new Error(`Backend returned status ${linkResponse.status}. Possibly because Preenlistment and Registration period is over.`);
           }
-        );
-        if (!linkResponse.ok) {
-          throw new Error(`Backend returned status ${linkResponse.status}. Possibly because Preenlistment and Registration period is over.`);
+        } catch (err) {
+          status.textContent = 'Error contacting backend: ' + err.message;
+          throw err;
+        }
+
+        // 5. Determine if HTML or text error muna yung nakuha na JSON from POST method
+        const text = await linkResponse.text();
+        let linkJSON;
+        try {
+          linkJSON = JSON.parse(text)
+        } catch(e) {
+          console.error('Non-JSON form!', endpointCall, text);
+          throw new Error('Backend error for ' + endpointCall);
+        }
+
+        if (!linkJSON) {
+          status.textContent = 'No schedules found.';
+        } else {
+          status.textContent = ''; // Reset the textContent
+          // console.log('Ranked Sched', linkJSON.data);
+          scheduleCache.set(urlKey, linkJSON.data); 
+
+          renderTable(linkJSON.data, rawProfs, strict, forbiddenSlots);
         }
       } catch (err) {
-        status.textContent = 'Error contacting backend: ' + err.message;
-        throw err;
+        console.error(err);
+        status.textContent = 'Error: ' + err.message;
       }
-
-      // 5. Determine if HTML or text error muna yung nakuha na JSON from POST method
-      const text = await linkResponse.text();
-      let linkJSON;
-      try {
-        linkJSON = JSON.parse(text)
-      } catch(e) {
-        console.error('Non-JSON form!', endpointCall, text);
-        throw new Error('Backend error for ' + endpointCall);
-      }
-
-      console.log('linkJSON', linkJSON);
-
-      if (!linkJSON) {
-        status.textContent = 'No schedules found.';
-      } else {
-        status.textContent = '';
-        console.log('Ranked Sched', linkJSON.data);
-        renderTable(linkJSON.data, rawProfs, strict);
-      }
-    } catch (err) {
-      console.error(err);
-      status.textContent = 'Error: ' + err.message;
     }
   });
 
-
   function hasProf(item, profSubstr) {
-    const courseKey  = Object.keys(item)[0];
+    const courseKey = Object.keys(item)[0];
     const sectionObj = item[courseKey][0];
     const sectionKey = Object.keys(sectionObj)[0];
-    const details    = sectionObj[sectionKey][0];
-    const words = details.Instructors
-      .toLowerCase()
-      .replace(',', '')
-      .split(' ');
+    const details = sectionObj[sectionKey][0];
+    const words = details.Instructors.toLowerCase().replace(',', '').split(' ');
     return words.includes(profSubstr);
   }
 
+  function getFilteredGroups(groups, rawProfs, strict, forbiddenSlots) {
+    // TODO: Optimize this. Currently runs in O(GFS)
+    return groups.filter(group => {
+      // Filter 1: Forbidden time slots. Basically iterate day, slot of forbidden then check if each of those is in conflict with each schedule combination
+      const hasConflict = forbiddenSlots.some(({ day, slot }) => {
+        // does any entry in this combo occupy that day+slot?
+        return group.some(item => {
+          const courseKey = Object.keys(item)[0];
+          const sectionArray = item[courseKey];  // [ { WFU: [...] }, … ]
 
-  function renderTable(groups, rawProfs, strict) {
-    let anyRendered = false;
+          // flatten out all schedule entries for this group item
+          return sectionArray.some(sectionObj => {
+            const sectionName = Object.keys(sectionObj)[0];
+            const schedules = sectionObj[sectionName];  // [ {...}, {...} ]
+
+            // now check *any* of those details objects for a conflict
+            return schedules.some(details => {
+              const days = dayMap[details.Day] || [];
+              if (!days.includes(day)) return false;
+
+              const [startSlot, endSlot] = timeToSlots(details.Time);
+              return startSlot <= slot && slot <= endSlot;
+            });
+          });
+        });
+      });
+      // Check if may conflict with forbidden time slots. If so, skip.
+      if (hasConflict) return false; // skip this combo
+
+      
+      // Filter 2: Fave prof
+      if (rawProfs.length > 0) {
+        let includeGroup = true;
+        if (strict) {
+          // every prof substring must appear in at least one item
+          includeGroup = rawProfs.every(rp =>
+            group.some(item => hasProf(item, rp))
+          );
+        } else {
+          // at least one match in the group
+          includeGroup = group.some(item =>
+            rawProfs.some(rp => hasProf(item, rp))
+          );
+        }
+
+        // Check if any professor in rawProfs is in the Instructors string. If so, skip.
+        if (!includeGroup) return false;  // skip this combo
+      } 
+
+      // Passed all the filters here! Nice!
+      return true; 
+    })
+  }
+
+  function renderTable(groups, rawProfs, strict, forbiddenSlots) {
+    const filtered = getFilteredGroups(groups, rawProfs, strict, forbiddenSlots);
+    // console.log('filtered', filtered);
+
+    if (filtered.length === 0) {
+      document.getElementById('results').innerHTML = '<p>⚠️ No matching combinations found.</p>';
+      return;
+    }
 
     const results = document.getElementById('results');
-    results.innerHTML = '';
+    results.scrollTop = 0; // This fixes the not resetting the scroll to top bug!
+    results.innerHTML = ''; // Clear everything
 
     const cols = ['Course','Section','Day','Time','Instructors','Probability'];
     const table = document.createElement('table');
     table.classList.add('sched-table');
 
     // Build a reusable header row (we’ll clone it for each group)
-    // Basically this is template for the columns.
+    // Basically this is template for the columns
     const headerTemplate = document.createElement('tr');
     cols.forEach(c => {
       const th = document.createElement('th');
@@ -202,33 +437,69 @@ document.addEventListener('DOMContentLoaded', () => {
       headerTemplate.appendChild(th);
     });
 
-    groups.forEach((group, group_index) => {
-      // Filter 1.1 Filter this group if meron man siyang at least 1 fave prof in it
-      if (rawProfs.length > 0) {
-        let includeGroup = true;
-        if (rawProfs.length > 0) {
-          if (strict) {
-            // every prof substring must appear in at least one item
-            includeGroup = rawProfs.every(rp =>
-              group.some(item => hasProf(item, rp))
-            );
-          } else {
-            // at least one match in the group
-            includeGroup = group.some(item =>
-              rawProfs.some(rp => hasProf(item, rp))
-            );
-          }
-        }
 
-        // Check if any professor in rawProfs is in the Instructors string
-        if (!includeGroup) return;  // skip this combo
-      } 
+    // This part is important for dynamically loading every 20 combination of schedules.
+    // This is so that we don't overload the whole thing by feeding the whole table (if there are many schedule combinations)
+    // Initial Chunk
+    currentStart = 0;
+    results.appendChild(table); // Append table before rendering rows
+    
+    // Show the sentinel
+    // This will be the placeholder for a chunk
+    const sentinel = document.createElement('div');
+    sentinel.id = 'load-sentinel';
+    results.appendChild(sentinel);
+
+    // Render the first <= 20 schedule combinations 
+    renderChunk(filtered, rawProfs, strict, forbiddenSlots, cols, table, headerTemplate);
+
+
+    results.removeEventListener('scroll', () => {
+      // Adding a removeEventListener since by default, addEventListener persists after the first time they are called! (https://developer.chrome.com/blog/addeventlistener-once)
+      // This fixes the multiple times this addEventListener is called for every scroll, instead of actually being called when it reaches threshold.
+      // We also clear results.innerHTML, sure. But, addEventListener still lives there since we just knew that they persist even when clearing the contents.
+
+      // How close to bottom before loading more?
+      const threshold = 50; // 50 px from the bottom
+      if (results.scrollTop + results.clientHeight >= table.offsetHeight - threshold) {
+        if (currentStart < filtered.length) {
+          console.log('Render more chunk!');
+          renderChunk(filtered, rawProfs, strict, forbiddenSlots, cols, table, headerTemplate);
+        }
+      }
+    });
+
+    // Render the next <= 20 schedule combinations depending on how close to bottom the scroll is
+    results.addEventListener('scroll', () => {
+      // How close to bottom before loading more?
+      const threshold = 50; // 50 px from the bottom
+      if (results.scrollTop + results.clientHeight >= table.offsetHeight - threshold) {
+        if (currentStart < filtered.length) {
+          console.log('Render more chunk!');
+          renderChunk(filtered, rawProfs, strict, forbiddenSlots, cols, table, headerTemplate);
+        }
+      }
+    });
+
+    // If there are no combinations, show this messaage
+    if (!anyRendered) {
+      const noCombinationMsg = document.createElement('p');
+      noCombinationMsg.textContent = '⚠️ No matching combinations found.';
+      results.appendChild(noCombinationMsg)
+    }
+  }
+
+  function renderChunk(groups, rawProfs, strict, forbiddenSlots, cols, table, headerTemplate) {
+    const end = Math.min(groups.length, currentStart + CHUNK_SIZE); // For deciding if how many to show at once initially
+
+    for (let i = currentStart; i < end; i++) {
+      const group = groups[i];
 
       // 1) Group header
       const groupRow = table.insertRow();
       const cell = groupRow.insertCell();
       cell.colSpan = cols.length;
-      cell.textContent = `Combination ${group_index + 1}`; 
+      cell.textContent = `Combination ${i + 1}`; 
       cell.classList.add('group-header');
       
       // 2) Column headers
@@ -242,56 +513,68 @@ document.addEventListener('DOMContentLoaded', () => {
       group.forEach(item => {
         // Drill into your nested object exactly like before:
         const courseKey = Object.keys(item)[0];
-        const sectionKey = Object.keys(item[courseKey][0])[0];
-        const details = item[courseKey][0][sectionKey][0];
+        const sectionArray = item[courseKey];
 
-        const row = table.insertRow();
-        row.insertCell().textContent = courseKey;
-        row.insertCell().textContent = sectionKey;
-        row.insertCell().textContent = details.Day;
-        row.insertCell().textContent = details.Time;
+        sectionArray.forEach(sectionObj => {
+          const sectionName = Object.keys(sectionObj)[0];
+          const schedules = sectionObj[sectionName];
 
-        // ---- Instructors Part ----
-        // Replace this part with the RUPP part logic.
-        // row.insertCell().textContent = details.Instructors;
-        const instructorCell = row.insertCell();
-        const rawName = details.Instructors.trim(); // Remove spaces na rin
+          schedules.forEach(details => {
+            const row = table.insertRow();
+            row.insertCell().textContent = courseKey;
+            row.insertCell().textContent = sectionName;
+            row.insertCell().textContent = details.Day;
+            row.insertCell().textContent = details.Time;
 
-        // For not to be a headache, let's normalize rawName into:
-        // 'firstName lastName'
-        // e.g. Coronel, Juan Felipe -> JuanFelipe Coronel (normalized)
-        let normalized = rawName;
-        if (rawName.includes(',')) {
-          const parts = rawName.split(',');
-          const last = parts[0].trim();
-          const first = parts[1].trim();
-          normalized = `${first} ${last}`
-        }
+            // ---- Instructors Part ----
+            // Replace this part with the RUPP part logic.
+            // row.insertCell().textContent = details.Instructors;
+            const instructorCell = row.insertCell();
+            const rawName = details.Instructors.trim(); // Remove spaces na rin
 
-        // Then, lowercase it so we can access keys from teacherMap
-        // e.g. juanfelipe coronel
-        const teacherKey = normalized.toLowerCase();
-        const id = teacherMap.get(teacherKey);
+            // For not to be a headache, let's normalize rawName into:
+            // 'firstName lastName'
+            // e.g. Coronel, Juan Felipe -> JuanFelipe Coronel (normalized)
+            let normalized = rawName;
+            if (rawName.includes(',')) {
+              const parts = rawName.split(',');
+              const last = parts[0].trim();
+              const first = parts[1].trim();
+              normalized = `${first} ${last}`
+            }
 
-        if (id) {
-          instructorCell.innerHTML = 
-          `
-            <a href="https://rupp.onrender.com/view/${id}" 
-              target="_blank"
-              rel="noopener noreferrer"
-              data-rupp-id="${id}">
-              ${details.Instructors}
-            </a>
-          `;
-        } else {
-          instructorCell.textContent = details.Instructors;
-        }
-        // ---- Instructors Part ----
+            // Then, lowercase it so we can access keys from teacherMap
+            // e.g. juanfelipe coronel
+            const teacherKey = normalized.toLowerCase();
+            const id = teacherMap.get(teacherKey);
 
-        row.insertCell().textContent = String(details.Probability) + '%';
-        averageProbability += Number(details.Probability); // also add for average
+            if (id) {
+              instructorCell.innerHTML = 
+              `
+                <a href="https://rupp.onrender.com/view/${id}" 
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  data-rupp-id="${id}">
+                  ${details.Instructors}
+                </a>
+              `;
+            } else {
+              instructorCell.textContent = details.Instructors;
+            }
+            // ---- Instructors Part ----
 
-        anyRendered = true;
+            
+            if (details.Probability !== null) {
+              row.insertCell().textContent = String(Math.floor(details.Probability * 100) / 100) + '%';
+              // console.log('PROB', details.Probability);
+              averageProbability += Number(details.Probability); // also add for average
+            } else {
+              row.insertCell().textContent = '';
+            }
+
+            anyRendered = true;
+          })
+        })
       });
 
       // 4) Insert average probability at the last col
@@ -303,24 +586,17 @@ document.addEventListener('DOMContentLoaded', () => {
       averageCell.textContent = 'Average Probability:';
 
       // Show actual average probability
-      const valueCell = average.insertCell();
+      const valueCell = averageRow.insertCell();
       valueCell.textContent = (averageProbability / group.length).toFixed(2) + '%';
       valueCell.style.fontWeight = 'bold';
 
       // 5) Spacer
-      const spacer = table.insertRow();
-      const sp = spacer.insertCell();
-      sp.colSpan = cols.length;
-      sp.classList.add('group-spacer');
-    });
-
-    // Adding the result to id=results in HTML
-    if (anyRendered) {
-      results.appendChild(table);
-    } else {
-      const noCombinationMsg = document.createElement('p');
-      noCombinationMsg.textContent = '⚠️ No matching combinations found.';
-      results.appendChild(noCombinationMsg)
+      const spacerRow = table.insertRow();
+      const spacerCell = spacerRow.insertCell();
+      spacerCell.colSpan = cols.length;
+      spacerCell.classList.add('group-spacer');
     }
+
+    currentStart = end;
   }
 });

--- a/popup.js
+++ b/popup.js
@@ -746,8 +746,8 @@ document.addEventListener('DOMContentLoaded', async () => {
 
       let combinedProbability = 1;
 
-      const averageProbabilityHeader = document.createElement('div');
-      averageProbabilityHeader.classList.add('combo-probability');
+      const combinedProbabilityHeader = document.createElement('div');
+      combinedProbabilityHeader.classList.add('combo-probability');
 
       const timetableCombo = document.createElement('div');
       timetableCombo.classList.add('timetable-combo');
@@ -815,8 +815,8 @@ document.addEventListener('DOMContentLoaded', async () => {
       });
 
       // Append combined probability to combinationHeader
-      averageProbabilityHeader.textContent = 'Combined Probability: ' + (combinedProbability * 100).toFixed(2) + '%';
-      combinationHeader.appendChild(averageProbabilityHeader);
+      combinedProbabilityHeader.textContent = 'Combined Probability: ' + (combinedProbability * 100).toFixed(2) + '%';
+      combinationHeader.appendChild(combinedProbabilityHeader);
       comboWrapper.appendChild(combinationHeader);
 
       // Append the combo at the bottom of the container
@@ -907,8 +907,8 @@ document.addEventListener('DOMContentLoaded', async () => {
 
       let combinedProbability = 1;
 
-      const averageProbabilityHeader = document.createElement('div');
-      averageProbabilityHeader.classList.add('combo-probability');
+      const combinedProbabilityHeader = document.createElement('div');
+      combinedProbabilityHeader.classList.add('combo-probability');
 
       const timetableCombo = document.createElement('div');
       timetableCombo.classList.add('timetable-combo');
@@ -1032,8 +1032,8 @@ document.addEventListener('DOMContentLoaded', async () => {
       }
 
       // Append combined probability to combinationHeader
-      averageProbabilityHeader.textContent = 'Combined Probability: ' + (combinedProbability * 100).toFixed(2) + '%';
-      combinationHeader.appendChild(averageProbabilityHeader);
+      combinedProbabilityHeader.textContent = 'Combined Probability: ' + (combinedProbability * 100).toFixed(2) + '%';
+      combinationHeader.appendChild(combinedProbabilityHeader);
       comboWrapper.appendChild(combinationHeader);
 
       // Append the combo at the bottom of the container

--- a/popup.js
+++ b/popup.js
@@ -177,19 +177,23 @@ document.addEventListener('DOMContentLoaded', async () => {
 
 
   // This part is for awaiting the Promise for both fetching priority and RUPP data
+  // While fetching student priority and RUPP data, buttons should be disabled 
   const fetchBtn = document.getElementById('fetchBtn');
-  fetchBtn.disabled = true;  // start disabled
+  fetchBtn.disabled = true;  // Start disabled
+
+  const clearBtn = document.getElementById('clearPaint');
+  clearBtn.disabled = true; // Start disabled
 
   // Only fetch priority once!
   const status = document.getElementById('status');
   status.textContent = 'Fetching priorities...';
-  // 1.0 Get classmessages and scrape priorities HTML page
+  // Get classmessages and scrape priorities HTML page
   const classMsgResp = await fetch('https://crs.upd.edu.ph/user/view/classmessages', {
     credentials: 'include'
   });
   const classMsgHtml = await classMsgResp.text();
 
-  // 1.1 Feed the classmessages HTML page to /scrape-priority endpoint
+  // Feed the classmessages HTML page to /scrape-priority endpoint
   const prioResp = await fetch(`${BACKEND}/scrape-priority`, {
     method: 'POST',
     headers: {
@@ -221,7 +225,8 @@ document.addEventListener('DOMContentLoaded', async () => {
   } catch (e) {
     console.error("Could not load RUPP teacher map", e);
   } finally {
-    fetchBtn.disabled = false;  // Now safe to click
+    fetchBtn.disabled = false; // Now safe to click
+    clearBtn.disabled = false;  
   }
 
   status.textContent = '';

--- a/popup.js
+++ b/popup.js
@@ -87,7 +87,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   document.getElementById('toggleView').addEventListener('click', () => {
     if (!lastArgs) return; // nothing to show yet
     isVisual = !isVisual;
-    document.getElementById('toggleView').textContent = isVisual ? 'Switch to table' : 'Switch to visual';
+    document.getElementById('toggleView').textContent = isVisual ? 'Switch to table view' : 'Switch to visual view';
     // Rerender with the same filters + data
     renderTable(...lastArgs);
   });
@@ -200,6 +200,12 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   const clearBtn = document.getElementById('clearPaint');
   clearBtn.disabled = true; // Start disabled
+
+  const switchViewBtn = document.getElementById('toggleView');
+  switchViewBtn.disabled = true; // Start disabled
+
+  const showSimilarBtn = document.getElementById('showSimilar');
+  showSimilarBtn.disabled = true; // Start disabled
 
   // Only fetch priority once!
   const status = document.getElementById('status');
@@ -458,7 +464,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       // Passed all the filters here! Nice!
       // We can insert the similar shape algorithm here by appending into a dictionary called similarShapeCombinations, with sorted concatenated time slots as keys, and courses as values.
             
-      console.log('Filtered occupiedSet', occupiedSet);
+      // console.log('Filtered occupiedSet', occupiedSet);
 
       // Sort the occupiedSet for consistent ordering (optional, for debugging or grouping)
       const sortedOccupied = Array.from(occupiedSet).sort();
@@ -467,7 +473,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
       let timeSlotKey = sortedOccupied.join(',');
 
-      console.log('timeSlotKey', timeSlotKey);
+      // console.log('timeSlotKey', timeSlotKey);
 
       // Append the current group (course details) to the similarShapeCombinations map
       if (!similarShapeCombinations.has(timeSlotKey)) { // If first time palang nakikita
@@ -485,7 +491,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     const filtered = getFilteredGroups(groups, rawProfs, strict, forbiddenSlots);
     // console.log('filtered', filtered);
-    console.log('similarShapeCombinations', similarShapeCombinations);
+    // console.log('similarShapeCombinations', similarShapeCombinations);
 
     status.textContent = `Generated ${filtered.length} combinations.`; // Show a status of how many schedule combination was generated and filtered
     
@@ -516,14 +522,11 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     // Add a new button here that listens to activate renderSimilarShapeCombination
-    const similarShapeBtn = document.createElement('button');
-    similarShapeBtn.id = 'showSimilarShape';
-    similarShapeBtn.textContent = 'Show Similar Shape Combinations';
-    results.appendChild(similarShapeBtn);
+    const similarShapeBtn = document.getElementById('showSimilar');
 
     similarShapeBtn.addEventListener('click', () => {
       results.innerHTML = '';
-      renderSimilarShapeCombination(filtered, rawProfs, strict, forbiddenSlots, cols, table, headerTemplate); 
+      renderSimilarShapeCombination(); 
     });    
 
     // Append the table first
@@ -554,6 +557,9 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     // Observe the sentinel for when it's in view
     observer.observe(sentinel);
+
+    switchViewBtn.disabled = false;
+    showSimilarBtn.disabled = false;
 
     // If there are no combinations, show this message
     if (!anyRendered) {
@@ -800,7 +806,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
   }
 
-  function renderSimilarShapeCombination(groups, rawProfs, strict, forbiddenSlots, cols, table, headerTemplate) {
+  function renderSimilarShapeCombination() {
     const shapeSummaries = Array.from(similarShapeCombinations.entries()).map(
       ([shapeKey, groupsForShape]) => {
         const slots = shapeKey.split(',').map(pair => {
@@ -811,9 +817,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         return { slots, groupsForShape }
       }
     );
-    console.log('shapeSummaries', shapeSummaries);   
+    // console.log('shapeSummaries', shapeSummaries);   
 
-    // TODO: render here visually
     const end = Math.min(shapeSummaries.length, currentStart + CHUNK_SIZE); // For deciding how many to show at once initially
 
     const slotHeight = 15;
@@ -884,9 +889,16 @@ document.addEventListener('DOMContentLoaded', async () => {
       const shapeMap = new Map();
       sessions.forEach(sess => {
         const key = `${sess.dayIdx}|${sess.s}|${sess.e}`;
-        if (!shapeMap.has(key)) shapeMap.set(key, []);
-        shapeMap.get(key).push(sess);
+        if (!shapeMap.has(key)) {
+          shapeMap.set(key, []);
+        }
+
+        // Only push if this label is not already present in the array for this key
+        if (!shapeMap.get(key).some(existing => existing.label === sess.label)) {
+          shapeMap.get(key).push(sess);
+        }
       });
+
 
       // 5) Draw one <div class="block"> per cluster
       shapeMap.forEach(arr => {
@@ -898,13 +910,11 @@ document.addEventListener('DOMContentLoaded', async () => {
         block.style.top    = `${s*slotHeight - 10}px`;
         block.style.height = `${(e-s)*slotHeight}px`;
 
-        // tooltip list of all labels in this block
-        block.title = arr.map(x => x.label).join('\n');
         const sessionLabels = arr.map(x => x.label).join("\n");
         block.setAttribute('data-sessions', sessionLabels);
 
         // show the first course inside
-        block.innerHTML = `<strong>${arr[0].label}</strong>`;
+        block.innerHTML = arr.map(x => `<strong>${x.label}</strong>`).join('<br>');
         timetableCombo.appendChild(block);
       });
 
@@ -927,136 +937,5 @@ document.addEventListener('DOMContentLoaded', async () => {
       observer.disconnect();
       sentinel.remove();
     }
-
-  }
-
-  function renderSimilarShapeCombination(groups, rawProfs, strict, forbiddenSlots, cols, table, headerTemplate) {
-    const shapeSummaries = Array.from(similarShapeCombinations.entries()).map(
-      ([shapeKey, groupsForShape]) => {
-        const slots = shapeKey.split(',').map(pair => {
-          const [day, slot] = pair.split('|');
-          return { day: day, slot: parseFloat(slot) };
-        });
-
-        return { slots, groupsForShape }
-      }
-    );
-    console.log('shapeSummaries', shapeSummaries);   
-
-    // TODO: render here visually
-    const end = Math.min(shapeSummaries.length, currentStart + CHUNK_SIZE); // For deciding how many to show at once initially
-
-    const slotHeight = 15;
-    const dayWidth = 124.19;
-
-    shapeSummaries.forEach(({ slots, groupsForShape }, shapeIndex) => {
-      // wrapper + header
-      const comboWrapper = document.createElement('div');
-      comboWrapper.classList.add('combo-wrapper');
-
-      const hdr = document.createElement('div');
-      hdr.classList.add('combo-header');
-      hdr.innerHTML = `<div class="combo-number">Shape ${shapeIndex + 1}</div>`;
-      comboWrapper.appendChild(hdr);
-
-      // grid container
-      const timetableCombo = document.createElement('div');
-      timetableCombo.classList.add('timetable-combo');
-
-      // column headers
-      ['Mon','Tue','Wed','Thu','Fri','Sat'].forEach((d,i) => {
-        const dh = document.createElement('div');
-        dh.classList.add('day-header');
-        dh.style.gridColumn = (i+2).toString();
-        dh.textContent = d;
-        timetableCombo.appendChild(dh);
-      });
-
-      // row labels
-      for (let slot=0; slot<25; slot++){
-        const hour = 7+Math.floor(slot/2),
-              min  = slot%2?'30':'00',
-              ampm = hour<12?'AM':'PM',
-              h12  = ((hour+11)%12)+1;
-        const lbl = document.createElement('div');
-        lbl.classList.add('time-label');
-        lbl.style.gridRow = (slot+2).toString();
-        lbl.textContent = `${h12}:${min} ${ampm}`;
-        timetableCombo.appendChild(lbl);
-      }
-
-      // 3) Collect _all_ sessions in this shape
-      const sessions = [];
-      groupsForShape.forEach(group => {
-        group.forEach(item => {
-          const course = Object.keys(item)[0];
-          item[course].forEach(sectionObj => {
-            const section = Object.keys(sectionObj)[0];
-            sectionObj[section].forEach(detail => {
-              const days = dayMap[detail.Day] || [];
-              const [s,e] = timeToSlots(detail.Time);
-              days.forEach(fullDay => {
-                const dayIdx = ['Mon','Tue','Wed','Thu','Fri','Sat']
-                                .indexOf(fullDay.slice(0,3));
-                if (dayIdx >= 0) {
-                  sessions.push({
-                    dayIdx, s, e,
-                    label: `${course} ${section}`
-                  });
-                }
-              });
-            });
-          });
-        });
-      });
-
-      // 4) Cluster identical (dayIdx, s, e)
-      const shapeMap = new Map();
-      sessions.forEach(sess => {
-        const key = `${sess.dayIdx}|${sess.s}|${sess.e}`;
-        if (!shapeMap.has(key)) shapeMap.set(key, []);
-        shapeMap.get(key).push(sess);
-      });
-
-      // 5) Draw one <div class="block"> per cluster
-      shapeMap.forEach(arr => {
-        const { dayIdx, s, e } = arr[0];
-        const block = document.createElement('div');
-        block.classList.add('block');
-        block.style.left   = `${(dayIdx+1)*dayWidth - 67}px`;
-        block.style.width  = `${dayWidth-2}px`;
-        block.style.top    = `${s*slotHeight - 10}px`;
-        block.style.height = `${(e-s)*slotHeight}px`;
-
-        // tooltip list of all labels in this block
-        block.title = arr.map(x => x.label).join('\n');
-        const sessionLabels = arr.map(x => x.label).join("\n");
-        block.setAttribute('data-sessions', sessionLabels);
-
-        // show the first course inside
-        block.innerHTML = `<strong>${arr[0].label}</strong>`;
-        timetableCombo.appendChild(block);
-      });
-
-
-      anyRendered = true;
-      comboWrapper.appendChild(timetableCombo);
-      results.appendChild(comboWrapper);
-    });
-
-    currentStart = end;
-
-    // console.log('sentinel', sentinel);
-
-    // Append the sentinel at the bottom after each chunk is rendered
-    if (currentStart < shapeSummaries.length) {
-      results.appendChild(sentinel);
-    }
-
-    if (currentStart >= shapeSummaries.length) {
-      observer.disconnect();
-      sentinel.remove();
-    }
-
   }
 });

--- a/popup.js
+++ b/popup.js
@@ -350,49 +350,6 @@ document.addEventListener('DOMContentLoaded', () => {
       return;
     }
 
-    // Add a new button here that listens to activate renderSimilarShapeCombination
-    const similarShapeBtn = document.createElement('button');
-    similarShapeBtn.id = 'showSimilarShape';
-    similarShapeBtn.textContent = 'Show Similar Shape Combinations';
-    results.appendChild(similarShapeBtn);
-
-    similarShapeBtn.addEventListener('click', () => {
-      results.innerHTML = '';
-      renderSimilarShapeCombination(filtered, rawProfs, strict, forbiddenSlots, cols, table, headerTemplate); 
-    });    
-
-    if (similarShapeCombinations.size === 0) {
-      results.innerHTML = '<p>⚠️ No matching combinations found.</p>';
-      return;
-    }
-
-    // Add a new button here that listens to activate renderSimilarShapeCombination
-    const similarShapeBtn = document.createElement('button');
-    similarShapeBtn.id = 'showSimilarShape';
-    similarShapeBtn.textContent = 'Show Similar Shape Combinations';
-    results.appendChild(similarShapeBtn);
-
-    similarShapeBtn.addEventListener('click', () => {
-      results.innerHTML = '';
-      renderSimilarShapeCombination(filtered, rawProfs, strict, forbiddenSlots, cols, table, headerTemplate); 
-    });    
-
-    if (similarShapeCombinations.size === 0) {
-      results.innerHTML = '<p>⚠️ No matching combinations found.</p>';
-      return;
-    }
-
-    // Add a new button here that listens to activate renderSimilarShapeCombination
-    const similarShapeBtn = document.createElement('button');
-    similarShapeBtn.id = 'showSimilarShape';
-    similarShapeBtn.textContent = 'Show Similar Shape Combinations';
-    results.appendChild(similarShapeBtn);
-
-    similarShapeBtn.addEventListener('click', () => {
-      results.innerHTML = '';
-      renderSimilarShapeCombination(filtered, rawProfs, strict, forbiddenSlots, cols, table, headerTemplate); 
-    });    
-
     // Append the table first
     currentStart = 0;
     results.appendChild(table);

--- a/popup.js
+++ b/popup.js
@@ -197,6 +197,12 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   })();
 
+  document.getElementById('clearPaint').addEventListener('click', () => {
+    document.querySelectorAll('.grid-cell').forEach(cell => {
+      cell.dataset.blocked = 'false';
+      cell.classList.remove('blocked');
+    });
+  });
 
   document.getElementById('fetchBtn').addEventListener('click', async () => {
     // Fetch from the timetable


### PR DESCRIPTION
pr:
 - i realized i wasn't sorting the schedules when filtering because my old strategy was to sort via the backend. but now we got the filtering logic in the client side, i decided to sort the schedules in the client side as well. hence, i need to make some changes in the backend so that i don't sort twice.
 - combined probability for the similar shape schedule combinations is currently using probability of at least one (`probAtLeastOne(ps)`). i think using probability of getting exactly one subject is not the case because there will be a case wherein both two course schedule have 100% probability of getting into, which doesn't make sense here. 
 - also fixed the infinite scrolling of similarly shaped schedules via a temporary container called `DocumentFragment`. this lets us build up DOM elements in memory before actually adding it into the page.